### PR TITLE
File:// Support

### DIFF
--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -134,6 +134,8 @@ class DownloadTask(object):
     def from_protocol_string(clz, protocol_string, source_prefix=None):
         if protocol_string.lower() == 'http':
             return URLDownloadTask(source_prefix)
+        elif protocol_string.lower() == 'file':
+            return URLDownloadTask(source_prefix)
         elif protocol_string.lower() == 'ftp':
             return URLDownloadTask(source_prefix)
         elif protocol_string.lower() == 'esri':

--- a/openaddr/tests/sources/us-ca-alameda_county-local.json
+++ b/openaddr/tests/sources/us-ca-alameda_county-local.json
@@ -1,0 +1,30 @@
+{
+    "schema": 2,
+    "coverage": {
+        "US Census": {
+            "geoid": "06001",
+            "name": "Alameda County",
+            "state": "California"
+        },
+        "country": "us",
+        "state": "ca",
+        "county": "Alameda"
+    },
+    "layers": {
+        "addresses": [{
+            "name": "default",
+            "data": "file:///tmp/us-ca-alameda.zip",
+            "license": { "url": "http://www.acgov.org/acdata/terms.htm" },
+            "year": "",
+            "protocol": "file",
+            "compression": "zip",
+            "conform": {
+                "lon": "X",
+                "lat": "Y",
+                "number": "ST_NUM",
+                "street": ["FEANME", "FEATYP"],
+                "format": "shapefile"
+            }
+        }]
+    }
+}


### PR DESCRIPTION
### Context

Add support for sources with `file://` prefix

Ref: https://github.com/openaddresses/batch/issues/134