### PR TITLE
use polylabel for address point from polygon

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -22,6 +22,8 @@ from uuid import uuid4
 from .sample import sample_geojson, stream_geojson
 
 from osgeo import ogr, osr, gdal
+from shapely.wkt import loads
+from shapely.ops import polylabel
 ogr.UseExceptions()
 
 def gdal_error_handler(err_class, err_num, err_msg):
@@ -728,15 +730,16 @@ def ogr_source_to_csv(source_config, source_path, dest_path):
                 if source_config.layer == "addresses":
                     # For Addresses - Calculate the centroid on surface of the geometry and write it as X and Y columns
                     try:
-                        centroid = geom.PointOnSurface()
+                        shapely_geom = loads(geom.ExportToWkt())
+                        centroid_wkt = polylabel(shapely_geom).wkt
                     except RuntimeError as e:
                         if 'Invalid number of points in LinearRing found' not in str(e):
                             raise
                         xmin, xmax, ymin, ymax = geom.GetEnvelope()
 
-                        centroid = ogr.CreateGeometryFromWkt("POINT ({} {})".format(xmin/2 + xmax/2, ymin/2 + ymax/2))
+                        centroid_wkt = "POINT ({} {})".format(xmin/2 + xmax/2, ymin/2 + ymax/2)
 
-                    row[GEOM_FIELDNAME] = centroid.ExportToWkt()
+                    row[GEOM_FIELDNAME] = centroid_wkt
                 else:
                     row[GEOM_FIELDNAME] = geom.ExportToWkt()
             else:


### PR DESCRIPTION
When an address source contains polygons, currently PointOnSurface is used to convert that into an address point. In this example below, the blue dots are centroids based on the polygons shown behind (importantly these are not the result of this batch code, as this example is from a point source).

While this is okay, a nicer location for the address point would be more where the background map shows it, closer to the pole of inaccessibility as created by polylabel.

![2021-04-19_21-05](https://user-images.githubusercontent.com/117278/115226819-00a36d80-a153-11eb-9a5e-b83b7b55e4fe.png)

While there is no single correct location of where the point should be located, indeed different applications would want different locations like:

- street frontage point
- best position for labelling (polylabel)
- best position for analysis (point on surface or centroid)

This PR is not complete (I haven't added shapely as a dependency, or done any testing yet, and I haven't yet looked at actual results from PointOnSurface and how it compares with Polylabel results for real world data) but shows in principle a potential change.

Not sure what kind of performance hit this would have.