### PR TITLE
Custom EPSG should use traditional coord order

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -463,6 +463,10 @@ def ogr_source_to_csv(source_config, source_path, dest_path):
             _L.debug("SRS tag found specifying %s", srs)
             inSpatialRef = osr.SpatialReference()
             inSpatialRef.ImportFromEPSG(int(srs[5:]))
+
+            if int(osgeo.__version__[0]) >= 3:
+                # GDAL 3 changes axis order: https://github.com/OSGeo/gdal/issues/1546
+                inSpatialRef.SetAxisMappingStrategy(osgeo.osr.OAMS_TRADITIONAL_GIS_ORDER)
         else:
             # OGR is capable of doing more than EPSG, but so far we don't need it.
             raise Exception("Bad SRS. Can only handle EPSG, the SRS tag is %s", srs)


### PR DESCRIPTION
### Context

It appears as though features retrieved from a gdal source use traditional coordinate order. This results in our reading of OGR sources working perfectly if the Proj string is built directly from the source - but failing if specified manually.

### Actions
- [x] Use traditional coord order for custom SRS
- [ ] Generate list of OGR sources with manual `srs` tags and make sure I don't create another regression mess

Fixes: https://github.com/openaddresses/batch-machine/issues/26

cc @stefanb 