### PR TITLE
Remove py3-gdal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM osgeo/gdal:alpine-normal-3.4.2
 
 RUN apk add nodejs yarn git python3 python3-dev py3-pip \
-    py3-gdal make bash sqlite-dev zlib-dev \
+    make bash sqlite-dev zlib-dev \
     postgresql-libs gcc g++ musl-dev postgresql-dev cairo \
     py3-cairo file
 


### PR DESCRIPTION
### Context

Py3-Gdal is causing a segmentation fault and based on it's removal does not affect the python package as I previously thought