### PR TITLE
Update GDAL & Runtime to Python3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM osgeo/gdal:alpine-normal-3.6.1
 
 RUN apk add nodejs yarn git python3 python3-dev py3-pip \
-    make bash sqlite-dev zlib-dev \
+    make bash sqlite-dev zlib-dev geos geos-dev \
     postgresql-libs gcc g++ musl-dev postgresql-dev cairo \
     py3-cairo file
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/gdal:alpine-normal-3.4.2
+FROM osgeo/gdal:alpine-normal-3.6.1
 
 RUN apk add nodejs yarn git python3 python3-dev py3-pip \
     make bash sqlite-dev zlib-dev \
@@ -6,7 +6,7 @@ RUN apk add nodejs yarn git python3 python3-dev py3-pip \
     py3-cairo file
 
 # Download and install Tippecanoe
-RUN git clone -b 1.36.0 https://github.com/mapbox/tippecanoe.git /tmp/tippecanoe && \
+RUN git clone -b 2.16.0 https://github.com/felt/tippecanoe.git /tmp/tippecanoe && \
     cd /tmp/tippecanoe && \
     make && \
     PREFIX=/usr/local make install && \

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'mock == 3.0.5',
 
         # https://github.com/uri-templates/uritemplate-py/
-        'uritemplate == 3.0.0',
+        'uritemplate == 4.1.1',
 
         # http://docs.python-requests.org/en/master/
         'requests == 2.28.1',

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ setup(
     },
     test_suite = 'openaddr.tests',
     install_requires = [
-        'dateutils == 0.6.6', 'ijson == 2.4',
+        'dateutils == 0.6.12', 'ijson == 2.4',
 
-        'simplejson == 3.17.2',
+        'simplejson == 3.18.0',
 
         # http://www.voidspace.org.uk/python/mock/
         'mock == 3.0.5',
@@ -44,20 +44,20 @@ setup(
         'uritemplate == 3.0.0',
 
         # http://docs.python-requests.org/en/master/
-        'requests == 2.27.1',
+        'requests == 2.28.1',
 
         # https://github.com/patrys/httmock
-        'httmock == 1.3.0',
+        'httmock == 1.4.0',
 
         # https://github.com/openaddresses/pyesridump
         'esridump == 1.11.0',
 
         # Used in openaddr.parcels
-        'Shapely == 1.7.1',
+        'Shapely == 2.0.0',
 
         # https://github.com/tilezen/mapbox-vector-tile
-        'mapbox-vector-tile==1.2.0',
-        'future==0.16.0',
-        'protobuf==3.5.1',
-        ]
+        'mapbox-vector-tile @ git+https://github.com/tilezen/mapbox-vector-tile.git@5249a23da696515f118564dbcc83b39216792454#egg=mapbox-vector-tile',
+        'future==0.18.2',
+        'protobuf==4.21',
+    ]
 )


### PR DESCRIPTION
### Context

I've spent hours trying to backport my local system to 3.7 after updating to Ubuntu 22.10 and I'm now convinced it's now easier to move this code forward to 3.10.....

cc/ @iandees 