### PR TITLE
Pmtiles support

### DIFF
--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -153,7 +153,7 @@ def process(source, destination, layer, layersource, do_preview, mapbox_key=None
                             preview_path = render_preview(conform_result.path, temp_dir, mapbox_key)
 
                         if do_preview:
-                            mbtiles_path = render_slippymap(conform_result.path, temp_dir)
+                            mbtiles_path = render_mbtiles(conform_result.path, temp_dir)
                             pmtiles_path = render_pmtiles(conform_result.path, temp_dir)
 
                         if not preview_path:
@@ -208,14 +208,14 @@ def render_preview(csv_filename, temp_dir, mapbox_key):
 
     return png_filename
 
-def render_slippymap(csv_filename, temp_dir):
+def render_mbtiles(csv_filename, temp_dir):
     '''
     '''
     try:
         mbtiles_filename = join(temp_dir, 'slippymap.mbtiles')
         slippymap.generate(mbtiles_filename, csv_filename)
     except Exception as e:
-        _L.error('%s in render_slippymap: %s', type(e), e)
+        _L.error('%s in render_mbtiles: %s', type(e), e)
         return None
     else:
         return mbtiles_filename

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -347,6 +347,8 @@ class TestOA (unittest.TestCase):
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -355,6 +357,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertIsNotNone(state['preview'])
         self.assertIsNotNone(state['slippymap'])
+        self.assertIsNotNone(state['pmtiles'])
 
         output_path = join(dirname(state_path), state['processed'])
         with open(output_path, encoding='utf8') as input:
@@ -390,6 +393,8 @@ class TestOA (unittest.TestCase):
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -398,6 +403,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertIsNotNone(state['preview'])
         self.assertIsNotNone(state['slippymap'])
+        self.assertIsNotNone(state['pmtiles'])
 
         output_path = join(dirname(state_path), state['processed'])
         with open(output_path, encoding='utf8') as input:
@@ -433,6 +439,8 @@ class TestOA (unittest.TestCase):
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -441,6 +449,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertIsNotNone(state['preview'])
         self.assertIsNotNone(state['slippymap'])
+        self.assertIsNotNone(state['pmtiles'])
 
         output_path = join(dirname(state_path), state['processed'])
 
@@ -473,6 +482,8 @@ class TestOA (unittest.TestCase):
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -481,6 +492,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertIsNotNone(state['preview'])
         self.assertIsNotNone(state['slippymap'])
+        self.assertIsNotNone(state['pmtiles'])
 
         output_path = join(dirname(state_path), state['processed'])
 
@@ -517,6 +529,8 @@ class TestOA (unittest.TestCase):
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -526,6 +540,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertIsNotNone(state['preview'])
         self.assertIsNotNone(state['slippymap'])
+        self.assertIsNotNone(state['pmtiles'])
 
         with open(join(dirname(state_path), state['processed'])) as file:
             rows = list(DictReader(file, dialect='excel'))
@@ -1441,7 +1456,10 @@ class TestState (unittest.TestCase):
             preview_path = file.name
 
         with open(join(self.output_dir, 'slippymap.mbtiles'), 'w') as file:
-            slippymap_path = file.name
+            mbtiles_path = file.name
+
+        with open(join(self.output_dir, 'slippymap.pmtiles'), 'w') as file:
+            pmtiles_path = file.name
 
         conform_result = ConformResult(processed=None,
                                        feat_count=999,
@@ -1460,7 +1478,8 @@ class TestState (unittest.TestCase):
                     destination=self.output_dir, log_handler=log_handler,
                     cache_result=cache_result, conform_result=conform_result,
                     temp_dir=self.output_dir, preview_path=preview_path,
-                    slippymap_path=slippymap_path, tests_passed=True)
+                    mbtiles_path=mbtiles_path, pmtiles_path=pmtiles_path,
+                    tests_passed=True)
 
         path1 = process_one.write_state(**args)
 


### PR DESCRIPTION
Uses Tippecanoe's [pmtiles support](https://github.com/felt/tippecanoe/pull/55) to output both an mbtiles and pmtiles formatted file when a preview is requested as part of processing the source.

Note that this keeps the existing state.txt output column named "slippymap" and adds a new one called "pmtiles".