### PR TITLE
Add support for geojsonld output

### DIFF
--- a/openaddr/slippymap.py
+++ b/openaddr/slippymap.py
@@ -10,12 +10,12 @@ from urllib.parse import urlparse
 import os, subprocess, json
 import requests
 
-def generate(mbtiles_filename, *filenames_or_urls):
+def generate(output_filename, *filenames_or_urls):
     '''
     '''
     cmd = 'tippecanoe', '-l', 'dots', '-r', '3', \
           '-n', 'OpenAddresses Dots', '-f', \
-          '-t', gettempdir(), '-o', mbtiles_filename
+          '-t', gettempdir(), '-o', output_filename
 
     tippecanoe = subprocess.Popen(cmd, stdin=subprocess.PIPE, bufsize=1)
 

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -1525,7 +1525,7 @@ class TestState (unittest.TestCase):
         self.assertEqual(state1['output'], 'output.txt')
         self.assertEqual(state1['preview'], 'preview.png')
         self.assertEqual(state1['slippymap'], 'slippymap.mbtiles')
-        self.assertEqual(state1['geojsonld'], 'out.geojsonld')
+        self.assertEqual(state1['geojsonld'], 'out.geojson')
         self.assertEqual(state1['tests passed'], True)
 
         #

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -68,6 +68,13 @@ def touch_second_arg_file(_, path, *args, **kwargs):
     with open(path, 'w') as file:
         file.write('yo')
 
+def return_path_in_second_arg_dir(_, path, *args, **kwargs):
+    ''' Write a short dummy file inside the directory specified in the first arg and return its path.
+    '''
+    with open(os.path.join(path, "out.geojson"), 'w') as file:
+        file.write('yo')
+    return os.path.join(path, "out.geojson")
+
 class TestOA (unittest.TestCase):
 
     def setUp(self):
@@ -344,15 +351,14 @@ class TestOA (unittest.TestCase):
              mock.patch('openaddr.process_one.render_geojsonld') as render_geojsonld:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            render_geojsonld.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, "addresses", "default", True, True, True, mapbox_key='mapbox-XXXX')
+            render_geojsonld.side_effect = return_path_in_second_arg_dir
+            state_path = process_one.process(source, self.testdir, "addresses", "default", True, True, True, True, mapbox_key='mapbox-XXXX')
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.geojson'))
         self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
-        self.assertTrue(render_geojsonld.mock_calls[0][1][0].endswith('.geojsonld'))
-        self.assertTrue(render_geojsonld.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.geojson'))
+        self.assertTrue(render_geojsonld.mock_calls[0][1][0].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -391,15 +397,18 @@ class TestOA (unittest.TestCase):
 
         with HTTMock(self.response_content), \
              mock.patch('openaddr.preview.render') as preview_ren, \
-             mock.patch('openaddr.slippymap.generate') as slippymap_gen:
+             mock.patch('openaddr.slippymap.generate') as slippymap_gen, \
+             mock.patch('openaddr.process_one.render_geojsonld') as render_geojsonld:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, "addresses", "default", True, mapbox_key='mapbox-XXXX')
+            render_geojsonld.side_effect = return_path_in_second_arg_dir
+            state_path = process_one.process(source, self.testdir, "addresses", "default", True, True, True, True, mapbox_key='mapbox-XXXX')
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.geojson'))
         self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.geojson'))
+        self.assertTrue(render_geojsonld.mock_calls[0][1][0].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -437,15 +446,18 @@ class TestOA (unittest.TestCase):
 
         with HTTMock(self.response_content), \
              mock.patch('openaddr.preview.render') as preview_ren, \
-             mock.patch('openaddr.slippymap.generate') as slippymap_gen:
+             mock.patch('openaddr.slippymap.generate') as slippymap_gen, \
+             mock.patch('openaddr.process_one.render_geojsonld') as render_geojsonld:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, "addresses", "default", True, mapbox_key='mapbox-XXXX')
+            render_geojsonld.side_effect = return_path_in_second_arg_dir
+            state_path = process_one.process(source, self.testdir, "addresses", "default", True, True, True, True, mapbox_key='mapbox-XXXX')
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.geojson'))
         self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.geojson'))
+        self.assertTrue(render_geojsonld.mock_calls[0][1][0].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -480,15 +492,18 @@ class TestOA (unittest.TestCase):
 
         with HTTMock(self.response_content), \
              mock.patch('openaddr.preview.render') as preview_ren, \
-             mock.patch('openaddr.slippymap.generate') as slippymap_gen:
+             mock.patch('openaddr.slippymap.generate') as slippymap_gen, \
+             mock.patch('openaddr.process_one.render_geojsonld') as render_geojsonld:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, "addresses", "default", True, mapbox_key='mapbox-XXXX')
+            render_geojsonld.side_effect = return_path_in_second_arg_dir
+            state_path = process_one.process(source, self.testdir, "addresses", "default", True, True, True, True, mapbox_key='mapbox-XXXX')
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.geojson'))
         self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.geojson'))
+        self.assertTrue(render_geojsonld.mock_calls[0][1][0].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -527,15 +542,18 @@ class TestOA (unittest.TestCase):
 
         with HTTMock(self.response_content), \
              mock.patch('openaddr.preview.render') as preview_ren, \
-             mock.patch('openaddr.slippymap.generate') as slippymap_gen:
+             mock.patch('openaddr.slippymap.generate') as slippymap_gen, \
+             mock.patch('openaddr.process_one.render_geojsonld') as render_geojsonld:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, "addresses", "default", True, mapbox_key='mapbox-XXXX')
+            render_geojsonld.side_effect = return_path_in_second_arg_dir
+            state_path = process_one.process(source, self.testdir, "addresses", "default", True, True, True, True, mapbox_key='mapbox-XXXX')
 
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.geojson'))
         self.assertTrue(slippymap_gen.mock_calls[1][1][0].endswith('.pmtiles'))
-        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.csv'))
+        self.assertTrue(slippymap_gen.mock_calls[1][1][1].endswith('.geojson'))
+        self.assertTrue(render_geojsonld.mock_calls[0][1][0].endswith('.csv'))
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -565,7 +583,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-carson-cached.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -585,7 +603,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-carson-old-cached.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -605,7 +623,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/tx/runnels.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -624,7 +642,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-oakland.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -643,7 +661,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-oakland-skip.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -662,7 +680,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-berkeley.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -681,7 +699,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-berkeley-404.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -698,7 +716,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ca-berkeley-apn.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -731,7 +749,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'pl-dolnoslaskie.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -747,7 +765,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'pl-lodzkie.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -777,7 +795,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'jp-fukushima2.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -807,7 +825,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ut.json')
 
         with mock.patch('openaddr.util.request_ftp_file', new=self.response_content_ftp):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -821,7 +839,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'iceland.json')
 
         with mock.patch('openaddr.util.request_ftp_file', new=self.response_content_ftp):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -845,7 +863,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'fr-paris.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -868,7 +886,7 @@ class TestOA (unittest.TestCase):
             raise Exception('Could not find a usable fr/la-réunion.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -882,7 +900,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/va/statewide.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -897,7 +915,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/oh/trumbull.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -912,7 +930,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/ks/brown_county.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -927,7 +945,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/pa/lancaster.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -955,7 +973,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'ua-63-city_of_kharkiv.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -969,7 +987,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/pa/bucks.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -997,7 +1015,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/nm/washington.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1027,7 +1045,7 @@ class TestOA (unittest.TestCase):
         with HTTMock(self.response_content):
             ofs = csv.field_size_limit()
             csv.field_size_limit(1)
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
             csv.field_size_limit(ofs)
 
         with open(state_path) as file:
@@ -1041,7 +1059,7 @@ class TestOA (unittest.TestCase):
         with HTTMock(self.response_content):
             ofs = csv.field_size_limit()
             csv.field_size_limit(sys.maxsize)
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
             csv.field_size_limit(ofs)
 
         with open(state_path) as file:
@@ -1073,7 +1091,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-wy-park.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1100,7 +1118,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-ny-orange.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1127,7 +1145,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'de/berlin.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1152,7 +1170,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/or/portland.json')
 
         with mock.patch('openaddr.util.request_ftp_file', new=self.response_content_ftp):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1181,7 +1199,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'nl/countrywide.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1206,7 +1224,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'be/wa/brussels-fr.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1247,7 +1265,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'it-52-statewide.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1273,7 +1291,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us/nj/statewide.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1299,7 +1317,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'cz-countrywide-bad-tests.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1314,7 +1332,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-or-curry.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1329,7 +1347,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'us-mi-grand_traverse.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1344,7 +1362,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'lake-man-gdb.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1376,7 +1394,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'lake-man-gdb-nested.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))
@@ -1408,7 +1426,7 @@ class TestOA (unittest.TestCase):
         source = join(self.src_dir, 'lake-man-gdb-nested-nodir.json')
 
         with HTTMock(self.response_content):
-            state_path = process_one.process(source, self.testdir, "addresses", "default", False)
+            state_path = process_one.process(source, self.testdir, "addresses", "default", False, False, False, False)
 
         with open(state_path) as file:
             state = dict(zip(*json.load(file)))


### PR DESCRIPTION
Tippecanoe doesn't like our CSV format (with a WKT geom column), so I'm going to write GeoJSON-LD as well and pipe that to Tippecanoe instead.