### PR TITLE
Use file extension from content disposition header instead of giving up

### DIFF
--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -207,8 +207,8 @@ def guess_url_file_extension(url):
                     if path_ext == attachment_ext:
                         _L.debug('Content-Disposition agrees: "{}"'.format(match.group('filename')))
                     else:
-                        _L.debug('Content-Disposition disagrees: "{}"'.format(match.group('filename')))
-                        path_ext = False
+                        _L.debug('Content-Disposition disagrees: "{}", using "{}" instead'.format(match.group('filename'), attachment_ext))
+                        path_ext = attachment_ext
 
         if not path_ext:
             #

--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -207,8 +207,11 @@ def guess_url_file_extension(url):
                     if path_ext == attachment_ext:
                         _L.debug('Content-Disposition agrees: "{}"'.format(match.group('filename')))
                     else:
-                        _L.debug('Content-Disposition disagrees: "{}", using "{}" instead'.format(match.group('filename'), attachment_ext))
-                        path_ext = attachment_ext
+                        _L.debug('Content-Disposition disagrees: "{}" says we should use "{}", using "{}" instead'.format(
+                            match.group('filename'),
+                            attachment_ext,
+                            path_ext,
+                        ))
 
         if not path_ext:
             #


### PR DESCRIPTION
Currently, when a source file's `content-disposition` response header has a file extension that disagrees with the `content-type` response header we give up and use .txt, which causes confusion later in the download/conform pipeline.

Instead of giving up, this switches to use the file extension calculated from the content-type.

This is meant to handle the errors seen in https://github.com/openaddresses/openaddresses/pull/6925