### PR TITLE
Include --skip-preview in openaddr-process-one example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can create an output folder and then run the batch process on the desired la
 
 ```
 mkdir my-output
-openaddr-process-one --layer addresses --layersource state example.json my-output
+openaddr-process-one --skip-preview --layer addresses --layersource state example.json my-output
 ```
 
 Review https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md for input json syntax.


### PR DESCRIPTION
To reduce the number of steps needed by new contributors to test batch-machine, include --skip-preview in the sample script to avoid needing to setup a Mapbox Access Token.