### PR TITLE
Fix output generation to handle edge case in first-non-empty function

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1078,7 +1078,10 @@ def row_convert_to_out(source_config, row):
             # Get a native field as specified in the conform object
             cfield = source_config.data_source['conform'].get(field)
 
-            if cfield:
+            # If the field is a string, it is a direct mapping to the source
+            # It might not be a string if it's a function that failed to
+            # resolve to an oa:-prefixed field.
+            if cfield and isinstance(cfield, str):
                 output["properties"][field] = row.get(cfield)
             else:
                 output["properties"][field] = ''

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -457,6 +457,44 @@ class TestConformTransforms (unittest.TestCase):
             }
         }, r)
 
+        "Test first_non_empty function with nothing found"
+        d = SourceConfig(dict({
+            "schema": 2,
+            "layers": {
+                "addresses": [{
+                    "name": "default",
+                    "conform": {
+                        "number": {
+                            "function": "first_non_empty",
+                            "fields": ["a", "b"]
+                        },
+                        "lon": "y",
+                        "lat": "x",
+                    },
+                    "fingerprint": "0000"
+                }]
+            }
+        }), "addresses", "default")
+        r = row_transform_and_convert(d, { "a": "", "b": "", GEOM_FIELDNAME: "POINT(-119.2 39.3)" })
+        self.assertEqual({
+            'type': 'Feature',
+            'geometry': {
+                "type": "Point",
+                "coordinates": [-119.2, 39.3]
+            },
+            'properties': {
+                "street": "",
+                "unit": "",
+                "number": "",
+                "city": "",
+                "region": "",
+                "district": "",
+                "postcode": "",
+                "id": "",
+                'hash': '7b1dc0b74cbc0162'
+            }
+        }, r)
+
     def test_row_canonicalize_unit_and_number(self):
         r = row_canonicalize_unit_and_number({}, {"number": "324 ", "street": " OAK DR.", "unit": "1"})
         self.assertEqual("324", r["number"])


### PR DESCRIPTION
For https://github.com/openaddresses/openaddresses/pull/7564

The `first_non_empty` conform function is the only one that can potentially not generate an output column with `oa:` prefix. If that happens, the code that generates the overall output will fail because it looks for an `oa:`-prefixed output to handle function output. If it doesn't find that, then it assumes the value in the `conform` dict is a string referencing a column in the source data directly. In the case where `first_non_empty` doesn't output anything, this output code will try to hash the dict that specifies the function and fail like in the PR above.

The fix here is to check if the selected conform field is a string before trying to treat it like a string.

I also added a test to check this behavior.