### PR TITLE
Skip None values in field_names_to_request

### DIFF
--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -348,11 +348,11 @@ class EsriRestDownloadTask(DownloadTask):
                 elif isinstance(v, list):
                     # It's a list of field names
                     fields |= set(v)
-                else:
+                else if v is not None:
                     fields.add(v)
 
         if fields:
-            return list(filter(None, sorted(fields)))
+            return list(sorted(fields))
         else:
             return None
 


### PR DESCRIPTION
Potential fix for #72. I haven't tested this as I'm not set up to run batch-machine locally, but I _think_ this is the root cause.

It seems like `filter()` and `sorted()` may have been firing in the wrong order, but we can remove the `filter()` call altogether by checking if `v is None` upfront.