### PR TITLE
Upgrade base image from GDAL 3.7.1 to 3.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM ghcr.io/osgeo/gdal:alpine-normal-3.7.1
+FROM ghcr.io/osgeo/gdal:alpine-normal-3.11.0
 
-RUN apk add --no-cache nodejs yarn git python3 python3-dev py3-pip \
-    make bash sqlite-dev zlib-dev geos geos-dev \
-    postgresql-libs gcc g++ musl-dev postgresql-dev cairo \
-    py3-cairo file ca-certificates \
-    && update-ca-certificates
+RUN apk add --no-cache nodejs yarn git python3-dev py3-pip \
+    make sqlite-dev zlib-dev geos-dev \
+    gcc g++ musl-dev postgresql-dev cairo \
+    py3-cairo file
 
 # Download and install Tippecanoe
 RUN git clone -b 2.31.0 https://github.com/felt/tippecanoe.git /tmp/tippecanoe && \
@@ -16,6 +15,6 @@ RUN git clone -b 2.31.0 https://github.com/felt/tippecanoe.git /tmp/tippecanoe &
 WORKDIR /usr/local/src/batch-machine
 ADD . /usr/local/src/batch-machine
 
-RUN pip3 install . && pip3 install --upgrade certifi
+RUN pip3 install --break-system-packages .
 
 CMD python3 test.py

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     test_suite = 'openaddr.tests',
     install_requires = [
-        'gdal == 3.7.1',
+        'gdal == 3.11.0',
 
         'dateutils == 0.6.12', 'ijson == 2.4',
 


### PR DESCRIPTION
## Summary

- Upgrade Docker base image from `ghcr.io/osgeo/gdal:alpine-normal-3.7.1` to `alpine-normal-3.11.0`
- Remove SSL cert workarounds from #98 (new image ships with up-to-date CA certs)
- Remove redundant `apk` packages already included in the new base image (`python3`, `bash`, `geos`, `postgresql-libs`)
- Update GDAL Python binding pin from 3.7.1 to 3.11.0

## Test plan

- [x] Docker image builds successfully
- [x] All 119 tests pass
- [x] Verified all required OGR formats are available (Shapefile, GeoJSON, CSV, GML, GeoPackage, FileGDB)
- [x] Verified CA certificates are current (2024-11-21)