### PR TITLE
Pin gdal base image to digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:alpine-normal-3.11.0
+FROM ghcr.io/osgeo/gdal:alpine-normal-3.11.0@sha256:edf2793e0f1ceb74ab12a1d85bd3404b541a113720fbc1e032613e7df2774f7c
 
 RUN apk add --no-cache nodejs yarn git python3-dev py3-pip \
     make sqlite-dev zlib-dev geos-dev \


### PR DESCRIPTION
## Summary
- `Dockerfile` FROMs `ghcr.io/osgeo/gdal:alpine-normal-3.11.0`, a mutable tag. Upstream rebuilt it with an Alpine/Python 3.12 toolchain that broke `pyexpat`'s musl ABI (`XML_SetAllocTrackerActivationThreshold: symbol not found`), which crashed `pip3 install` during `RUN pip3 install --break-system-packages .` and broke CI on every PR regardless of diff.
- Pins `FROM` to the current known-good multi-arch digest (`sha256:edf2793e...`) of `alpine-normal-3.11.0`, so the build no longer moves out from under CI when the tag is rebuilt upstream.
- Verified `docker build --no-cache --platform linux/amd64 .` completes successfully with the pinned digest (matches the CI runner architecture).

Fixes #104

## Test plan
- [x] `docker build --no-cache --platform linux/amd64 -t machine .` succeeds locally with the pinned digest
- [ ] CI "Python Tests" workflow passes on this PR